### PR TITLE
Fix opt function.

### DIFF
--- a/src/utils/helpers.jl
+++ b/src/utils/helpers.jl
@@ -597,3 +597,7 @@ Creates a Dict of `option name` -> `option value` for the given vector of [`Appl
 If the option is of `Subcommand` type, creates a dict for all its subcommands.
 """
 extops(ops::Vector) = Dict([(op.name, Int(op.type) < 3 ? extops(op.options) : op.value) for op in ops])
+"""
+Return an empty `Dict` if the list of options used is missing.
+"""
+extops(::Missing) = Dict()


### PR DESCRIPTION
Make it so calling `opt()` on a context where all the options where optional and the user did not provide options, return an empty Dict instead of throwing a method error calling `extops(::Missing)`.