### PR TITLE
Replace MaybeAny by Any

### DIFF
--- a/src/Dizkord.jl
+++ b/src/Dizkord.jl
@@ -18,7 +18,6 @@ const Optional{T} = Union{T, Missing}
 const Nullable{T} = Union{T, Nothing}
 const OptionalNullable{T} = Union{T, Missing, Nothing}
 const StringOrChar = Union{AbstractString, AbstractChar}
-const MaybeAny = Union{T, Missing} where T<:Any
 
 # Constant functions.
 donothing(args...; kwargs...) = nothing

--- a/src/types/interaction.jl
+++ b/src/types/interaction.jl
@@ -64,7 +64,7 @@ Application Command Option.
 More details [here](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure).
 """
 struct ApplicationCommandOption 
-    value::MaybeAny
+    value::Any
     type::Optional{OptionType}
     name::Optional{String}
     description::Optional{String}

--- a/src/types/types.jl
+++ b/src/types/types.jl
@@ -68,7 +68,6 @@ macro merge(T)
 end
 
 # Compute the expression needed to extract field k from keywords.
-field(k::QuoteNode, ::Type{Any}) = :(kwargs[$k])
 field(k::QuoteNode, ::Type{Snowflake}) = :(snowflake(kwargs[$k]))
 field(k::QuoteNode, ::Type{DateTime}) = :(datetime(kwargs[$k]))
 field(k::QuoteNode, ::Type{T}) where T = :($T(kwargs[$k]))

--- a/src/types/types.jl
+++ b/src/types/types.jl
@@ -74,7 +74,7 @@ field(k::QuoteNode, ::Type{T}) where T = :($T(kwargs[$k]))
 field(k::QuoteNode, ::Type{Vector{Snowflake}}) = :(snowflake.(kwargs[$k]))
 field(k::QuoteNode, ::Type{Vector{DateTime}}) = :(datetime.(kwargs[$k]))
 field(k::QuoteNode, ::Type{Vector{T}}) where T = :($T.(kwargs[$k]))
-field(k::QuoteNode, ::Type{MaybeAny}) = :(haskey(kwargs, $k) ? kwargs[$k] : missing)
+field(k::QuoteNode, ::Type{Any}) = :(haskey(kwargs, $k) ? kwargs[$k] : missing)
 function field(k::QuoteNode, ::Type{T}) where T <: Enum
     return :(kwargs[$k] isa Integer ? $T(Int(kwargs[$k])) :
              kwargs[$k] isa $T ? kwargs[$k] : $T(kwargs[$k]))


### PR DESCRIPTION
The union `MaybeAny` was previously defined as `Union{T, Missing} where T` which is exactly equivalent to `Any`. It only made sense to replace it by `Any`.